### PR TITLE
Added support for m68k compilers configured with --enable-lto etc.

### DIFF
--- a/makefile
+++ b/makefile
@@ -83,7 +83,7 @@ INC:=-I$(INC_DIR) -I$(SRC_DIR) -I$(RES_DIR) -I$(LIB_INC) -I$(LIB_RES)
 
 # default flags
 ARCH_FLAG:=-m68000
-DEF_FLAGS_M68K:=$(ARCH_FLAG) -Wall -fno-builtin $(INC)
+DEF_FLAGS_M68K:=$(ARCH_FLAG) -Wall -fno-builtin -fno-pie -no-pie -fno-stack-protector -fno-lto $(INC)
 DEF_FLAGS_Z80:=-i$(SRC_DIR) -i$(INC_DIR) -i$(RES_DIR) -i$(LIB_SRC) -i$(LIB_INC)
 
 release: FLAGS:=$(DEF_FLAGS_M68K) -O3 -fuse-linker-plugin -fno-web -fno-gcse -fno-unit-at-a-time -fomit-frame-pointer -flto

--- a/makefile_lib
+++ b/makefile_lib
@@ -47,7 +47,7 @@ LST:=$(SRC_C:.c=.lst)
 INC:=-I$(INC_DIR) -I$(SRC_DIR) -I$(RES_DIR)
 
 # default flags
-DEF_FLAGS_M68K:=-m68000 -Wall -fno-builtin $(INC)
+DEF_FLAGS_M68K:=-m68000 -Wall -fno-builtin -fno-pie -no-pie -fno-stack-protector -fno-lto $(INC)
 DEF_FLAGS_Z80:=-i$(SRC_DIR) -i$(INC_DIR)
 
 release: envcheck


### PR DESCRIPTION
I suggest those changes to make better support for some compilers. I was able to set SGDK up using sgdk_nix on Gentoo using m68k-gcc that I got up and running via [crossdev](https://wiki.gentoo.org/wiki/Cross_build_environment). However, there is a difference between m68k-gcc on Arch and on Gentoo. Running Arch `m68k-elf-gcc -###` yields:
```Using built-in specs.
COLLECT_GCC=/mnt/bin/m68k-elf-gcc
COLLECT_LTO_WRAPPER=/mnt/usr/bin/../libexec/gcc/m68k-elf/9.2.0/lto-wrapper
Target: m68k-elf
Configured with: ../gcc-9.2.0/configure --prefix=/usr --target=m68k-elf --enable-languages=c --disable-multilib --with-cpu=m68000 --with-system-zlib --with-libgloss --without-headers --disable-shared --disable-nls
Thread model: single
gcc version 9.2.0 (GCC)
```
While running Gentoo `m68k-unknown-linux-gnu-gcc -###` built by crossdev out of the box without any additional tweaking whatsoever yields the following on my machine:
```Using built-in specs.
COLLECT_GCC=m68k-unknown-linux-gnu-gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/m68k-unknown-linux-gnu/10.2.0/lto-wrapper
Target: m68k-unknown-linux-gnu
Configured with: /var/tmp/portage/cross-m68k-unknown-linux-gnu/gcc-10.2.0/work/gcc-10.2.0/configure --host=x86_64-pc-linux-gnu --target=m68k-unknown-linux-gnu --build=x86_64-pc-linux-gnu --prefix=/usr --bindir=/usr/x86_64-pc-linux-gnu/m68k-unknown-linux-gnu/gcc-bin/10.2.0 --includedir=/usr/lib/gcc/m68k-unknown-linux-gnu/10.2.0/include --datadir=/usr/share/gcc-data/m68k-unknown-linux-gnu/10.2.0 --mandir=/usr/share/gcc-data/m68k-unknown-linux-gnu/10.2.0/man --infodir=/usr/share/gcc-data/m68k-unknown-linux-gnu/10.2.0/info --with-gxx-include-dir=/usr/lib/gcc/m68k-unknown-linux-gnu/10.2.0/include/g++-v10 --with-python-dir=/share/gcc-data/m68k-unknown-linux-gnu/10.2.0/python --enable-languages=c,c++ --enable-obsolete --enable-secureplt --disable-werror --with-system-zlib --enable-nls --without-included-gettext --enable-checking=release --with-bugurl=https://bugs.gentoo.org/ --with-pkgversion='Gentoo 10.2.0 p1' --disable-esp --enable-libstdcxx-time --enable-poison-system-directories --with-sysroot=/usr/m68k-unknown-linux-gnu --disable-bootstrap --enable-__cxa_atexit --enable-clocale=gnu --disable-multilib --disable-fixed-point --enable-libgomp --disable-libssp --disable-libada --disable-systemtap --disable-vtable-verify --disable-libvtv --without-zstd --enable-lto --without-isl --disable-libsanitizer --enable-default-pie --enable-default-ssp
Thread model: posix
Supported LTO compression algorithms: zlib
gcc version 10.2.0 (Gentoo 10.2.0 p1)
```
In comparison, the latter has  `--enable-lto --enable-default-pie --enable-default-ssp`, which enables link time optimization, position independent executable and stack smashing protection, which we do not want. Luckily, there is an easy fix to work around that by supplying gcc with `-fno-pie -no-pie -fno-stack-protector -fno-lto` to revert those default settings back.
Of course, those changes should not make any impact on compilers with those settings disabled by default.