### PR TITLE
Changes for work with latest SGDK

### DIFF
--- a/env
+++ b/env
@@ -1,0 +1,3 @@
+# Motorola 68000 environnement
+export PATH="/opt/toolchains/genesis/m68k-elf/bin:$PATH"
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/toolchains/genesis/m68k-elf/libexec/gcc/m68k-elf/6.3.0

--- a/makefile_lib
+++ b/makefile_lib
@@ -1,7 +1,7 @@
 # Build SGDK library to be referenced in projects
 
 # specify SGDK root dir
-SGDK?=/opt/sgdk
+SGDK?=/opt/toolchains/genesis/sgdk
 
 # specify your M68k GNU toolchain prefix
 M68K_PREFIX?=m68k-elf-
@@ -47,11 +47,11 @@ LST:=$(SRC_C:.c=.lst)
 INC:=-I$(INC_DIR) -I$(SRC_DIR) -I$(RES_DIR)
 
 # default flags
-DEF_FLAGS_M68K:=-m68000 -Wall -fno-builtin $(INC)
+DEF_FLAGS_M68K:=-m68000 -Wall -Wextra -Wno-shift-negative-value -fno-builtin $(INC)
 DEF_FLAGS_Z80:=-i$(SRC_DIR) -i$(INC_DIR)
 
 release: envcheck
-release: FLAGS:=$(DEF_FLAGS_M68K) -O3 -fno-web -fno-gcse -fno-unit-at-a-time -fomit-frame-pointer
+release: FLAGS:=$(DEF_FLAGS_M68K) -O3 -fuse-linker-plugin -fno-lto -fno-web -fno-gcse -fno-unit-at-a-time -fomit-frame-pointer -flto
 release: $(SGDK)/lib/libmd.a
 
 debug: envcheck
@@ -59,7 +59,7 @@ debug: FLAGS:=$(DEF_FLAGS_M68K) -O1 -ggdb -DDEBUG=1
 debug: $(SGDK)/lib/libmd_debug.a
 
 asm: envcheck
-asm: FLAGS:=$(DEF_FLAGS_M68K) -O3 -fno-web -fno-gcse -fno-unit-at-a-time -fomit-frame-pointer -S
+asm: FLAGS:=$(DEF_FLAGS_M68K) -O3  -fuse-linker-plugin -fno-lto -fno-web -fno-gcse -fno-unit-at-a-time -fomit-frame-pointer -S
 asm: $(LST)
 
 all: release
@@ -87,19 +87,19 @@ clean: cleanobj
 	@rm -f $(SGDK)/lib/libmd.a $(SGDK)/lib/libmd_debug.a $(OBJ)
 
 $(SGDK)/lib/libmd.a: $(OBJ)
-	ar rs $(SGDK)/lib/libmd.a $(OBJ)
+	ar rs $(SGDK)/lib/libmd.a --plugin=liblto_plugin.so $(OBJ)
 
 $(SGDK)/lib/libmd_debug.a: $(OBJ)
-	ar rs $(SGDK)/lib/libmd_debug.a $(OBJ)
+	ar rs $(SGDK)/lib/libmd_debug.a --plugin=liblto_plugin.so $(OBJ)
 
 %.lst: %.c
 	$(CC) $(FLAGS) -c $< -o $@
 
 %.o: %.c
-	$(CC) $(FLAGS) -c $< -o $@
+	$(CC) $(FLAGS) -MMD -c $< -o $@
 
 %.o: %.s
-	$(CC) $(FLAGS) -c $< -o $@
+	$(CC) -x assembler-with-cpp -MMD $(FLAGS) -c $< -o $@
 
 %.s: %.res
 	$(RESCOMP) $< $@

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,8 @@ RED='\033[1;31m'
 YELLOW='\033[1;33m'
 GREEN='\033[1;32m'
 
+source .env
+
 function fail() {
 	echo -e "${RED}${1}${CLEAR}"
 	exit -1
@@ -16,7 +18,7 @@ function cmdcheck() {
 	command -v $1 >/dev/null || fail "not found!" && echo -e "${GREEN}found!${CLEAR}"
 }
 
-[[ -z "${SGDK}" ]] && SGDK='/opt/sgdk'
+[[ -z "${SGDK}" ]] && SGDK='/opt/toolchains/genesis/sgdk'
 [[ -z "${M68K_PREFIX}" ]] && M68K_PREFIX='m68k-elf-'
 echo -e "${BOLD}SGDK for *nix - Initial Setup${CLEAR}"
 read -ep "Please specify SGDK directory: " -i ${SGDK} SGDK
@@ -67,10 +69,24 @@ echo -e "${YELLOW}Building bintos...${CLEAR}"
 echo -e "${GREEN}Success!${CLEAR}"
 
 echo
+echo -e "${YELLOW}Building sizebnd...${CLEAR}"
+(export SGDK=${SGDK}; cd sgdk_tools/sizebnd && make && make install && make clean)
+[[ $? != 0 ]] && fail "Failed to build sizebnd"
+[[ -x ${SGDK_BIN}/sizebnd ]] || fail "Failed to install bnd"
+echo -e "${GREEN}Success!${CLEAR}"
+
+echo
 echo -e "${YELLOW}Building SGDK library...${CLEAR}"
 (export SGDK=${SGDK}; make -f makefile_lib && make -f makefile_lib cleanobj)
 [[ $? != 0 ]] && fail "Failed to build SGDK library"
 [[ -f ${SGDK}/lib/libmd.a ]] || fail "Failed to build SGDK library"
+echo -e "${GREEN}Success!${CLEAR}"
+
+echo
+echo -e "${YELLOW}Building SGDK debug library...${CLEAR}"
+(export SGDK=${SGDK}; make -f makefile_lib debug && make -f makefile_lib cleanobj)
+[[ $? != 0 ]] && fail "Failed to build SGDK library"
+[[ -f ${SGDK}/lib/libmd_debug.a ]] || fail "Failed to build SGDK debug library"
 echo -e "${GREEN}Success!${CLEAR}"
 
 echo

--- a/sgdk_tools/sizebnd/makefile
+++ b/sgdk_tools/sizebnd/makefile
@@ -1,0 +1,25 @@
+SGDK?=/opt/sgdk
+
+SIZEBND_SRC:=$(SGDK)/tools/sizebnd
+SRC_DIR:=$(SIZEBND_SRC)/src
+INC_DIR:=$(SIZEBND_SRC)/inc
+OUT_DIR:=$(SIZEBND_SRC)/out
+
+SRCEXT:=c
+SRC:=$(wildcard $(SRC_DIR)/*.c)
+
+CC:=gcc
+CFLAGS:=-fexpensive-optimizations -Os -s
+
+TARGET:=$(OUT_DIR)/sizebnd
+
+$(TARGET): $(SRC)
+	@mkdir -p $(OUT_DIR)
+	$(CC) $(CFLAGS) -I$(INC_DIR) -o $@ $^ -lm
+
+clean:
+	@rm -r $(TARGET)
+
+install:
+	@cp -f $(TARGET) $(SGDK)/bin
+	@echo "Copied $(TARGET) to $(SGDK)/bin"


### PR DESCRIPTION
Hi, I suggest various improvements, the first of which is to make makefiles compatible with the latest version of SGDK. This new version saves size in ROM (~ 100KB).

So I adapted the makefiles to make it work. An "env" file has been created to allow the script to find the Motorolla 68000 compiler and the plugins directory.

I added the number of CPUs in the makefiles to speed up the build project and library.

I added the "run" command to launch the emulator after build.

I added the SIZEBND tool in order to have a correct padding of the ROM.

I also modified the makefile in order to compile all the source files located in subdirectories.

You don't have to add all of these improvements, but compatibility with the new version of SGDK could be useful :)